### PR TITLE
fix multiple usage output on invalid arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core
+  colcon-core>=0.3.15
   PyYAML
 packages = find:
 tests_require =


### PR DESCRIPTION
Follow up of #7.

Leverage the new context manager from colcon/colcon-core#155 to gain the same fix and remove the duplicate logic.