### PR TITLE
Allow mixins to also specify boolean arguments

### DIFF
--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -64,6 +64,11 @@ class MixinArgumentDecorator(DestinationCollectorDecorator):
         """Wrap default value in a custom class."""
         if 'default' in kwargs:
             kwargs['default'] = DefaultValue(kwargs['default'])
+        # For store_`bool`, the default is the negation
+        elif kwargs.get('action') == 'store_true':
+            kwargs['default'] = DefaultValue(False)
+        elif kwargs.get('action') == 'store_false':
+            kwargs['default'] = DefaultValue(True)
         return super().add_argument(*args, **kwargs)
 
     def set_defaults(self, **kwargs):


### PR DESCRIPTION
Tested using following mixin. Allows for specifying other bool args like `--cmake-clean-first` etc

```
---
build:
  libcxx:
    merge-install: True
    cmake-args:
    - "-DCMAKE_C_COMPILER=clang-6.0"
    - "-DCMAKE_CXX_COMPILER=clang++-6.0"
    build-base: "clangbuild"
    install-base: "clanginstall"
```