### PR TITLE
Add -m short name for mixin.

### DIFF
--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -204,7 +204,7 @@ class MixinArgumentDecorator(DestinationCollectorDecorator):
         # the help and completer are skipped for now
         # they are updated later in _update_mixin_argument
         argument = group.add_argument(
-            '--mixin', nargs='*', metavar=('mixin1', 'mixin2'))
+            '-m', '--mixin', nargs='*', metavar=('mixin1', 'mixin2'))
 
         # makes the used verb available to choose the corresponding mixins
         parser.set_defaults(mixin_verb=verb)


### PR DESCRIPTION
Some of the most common operations in colcon are extremely verbose compared to other commandline tools.
The use case I'd most like to support here is to print build/test output to console.
The instinct for this is `-v`, or `--verbose` - but instead the user has to know to type `--event-handlers console_direct+`, which is not only 32 characters but also mixes hyphens and underscores. We can probably all agree this is not maximally ergonomic.

`colcon VERB --mixin` allows for fixing this to an extent by allowing for defining a mixin named `v` or `verbose` to provide the event handlers. However this still ends up as `--mixin v`, which is an improvement, but at 9 characters still isn't ideal compared to `-v`.

If `--mixin` can be abbreviated as `-m`, then the `-m v` option would allow the user to accomplish the goal in 4 characters.

This is the best I can think of beyond adding a `-v/--verbose` extension to colcon directly. Let me know if you think that would be a better move. I think the upside of abbreviating mixin is that other short options can be easily added in the user's own mixin repository, without having to build a full extension package.