### PR TITLE
Read additional mixins specified by an environment variable.

### DIFF
--- a/colcon_mixin/mixin/__init__.py
+++ b/colcon_mixin/mixin/__init__.py
@@ -36,9 +36,9 @@ def get_additional_mixin_paths():
 
     :rtype: list
     """
-    # Read additional paths from the environment variable, splitting on :.
-    env_var = os.environ.get(COLCON_MIXIN_PATH.name, "")
-    return [Path(x) for x in env_var.split(":") if x]
+    # Read additional paths from the environment variable.
+    env_var = os.environ.get(COLCON_MIXIN_PATH.name, '')
+    return [Path(x) for x in env_var.split(os.pathsep) if x]
 
 
 def get_mixin_files(path=None):

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,8 @@ junit_suite_name = colcon-mixin
 [options.entry_points]
 colcon_core.argument_parser =
     mixin = colcon_mixin.mixin.mixin_argument:MixinArgumentParserDecorator
+colcon_core.environment_variable =
+    mixin_path = colcon_mixin.mixin:COLCON_MIXIN_PATH
 colcon_core.extension_point =
     colcon_mixin.subverb = colcon_mixin.subverb:MixinSubverbExtensionPoint
 colcon_core.verb =


### PR DESCRIPTION
### Proposed change
This change allows specifying additional directories in which mixin files can be found. One or multiple directories can be provided through the `COLCON_MIXIN_PATH` environment variable. The mixins found in these director(y/ies) are available in addition to the ones found in `COLCON_HOME`.

### Rationale
@mikepurvis and I are working on some changes which means that our colleagues will soon be using `colcon` instead of `catkin` when they build their workspace locally during development. With `catkin` we currently provide a [profile](https://catkin-tools.readthedocs.io/en/latest/verbs/catkin_profile.html) to ensure the compile flags in developer workspaces are consistent with the ones used by the build system. With `colcon` we want to ensure similar behaviour. To achieve this we're setting a `COLCON_HOME` environment variable which points at a provided directory, in this directory we can provide mixins and a defaults file to ensure that invoking `colcon build` without any additional arguments uses the mixins we want (like the compilation flags).

However, we also want to enable individual devs to extend the provided mixins by writing their own. There can be only a single `COLCON_HOME` location, we wanted to avoid devs from having to make their own `COLCON_HOME` with symlinks to the provided mixin files (paths are also unstable, so links would break).

I explored using the `COLCON_DEFAULTS_FILE`, but using the `mixin-files` argument in that file doesn't work. I expect it's because of an interaction between the `colcon-mixin` and `colcon-defaults` plugins. I tried fixing this by copying [these lines](https://github.com/colcon/colcon-mixin/blob/1729436140bce23e50f2d70691385ac89508ca6f/colcon_mixin/mixin/mixin_argument.py#L155-L157) to line 164, but then the mixins are still not listed in the help file.

Instead, I think just allowing addition of arbitrary paths to be read for mixins is the most flexible, this also allows us to split out the mixins, instead of having to provide them all in a single `COLCON_HOME` directory. The mixins that are detected through this environment variable can be used from a `COLCON_DEFAULTS_FILE`. This means that developers can use mixins they developed in addition to the provided ones, and can use any of these mixins through the defaults file.

With this new environment variable it is easy for devs to extend the provided mixins with their own, and with the work by @jdlangs in https://github.com/colcon/colcon-defaults/pull/29 they can be easily consumed on a workspace-by-workspace basis, this allows for a development experience that's very close to `catkin` with its persistent configuration in the workspace.