### PR TITLE
Switch to ActionCollectorDecorator, add SuppressRequiredActions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ keywords = colcon
 
 [options]
 install_requires =
-  colcon-core>=0.7.0
+  colcon-core>=0.12.0
   PyYAML
 packages = find:
 zip_safe = true

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-mixin]
 No-Python2:
-Depends3: python3-colcon-core (>= 0.7.0), python3-yaml
+Depends3: python3-colcon-core (>= 0.12.0), python3-yaml
 Suite: bionic focal jammy stretch buster bullseye
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
It is necessary to suppress argument requirements during pre-parsing to ensure that missing positional arguments don't take precedence over the full --help text, which is already suppressed during pre-parsing.

Should be merged shortly after colcon/colcon-core#477 has been released, which is required for this change.