### PR TITLE
Propagate argument wrapping through default type conversion

### DIFF
--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -288,6 +288,7 @@ def _custom_wrap_type(original_type):
         if is_default:
             res = _custom_wrap_default_value(value)
         return res
+    return _impl
 
 
 def _custom_wrap_default_value(value):

--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -97,6 +97,9 @@ class MixinArgumentDecorator(
         if 'default' in kwargs:
             default_value = kwargs['default']
             kwargs['default'] = _custom_wrap_default_value(default_value)
+            type_value = kwargs.get('type')
+            if isinstance(default_value, str) and callable(type_value):
+                kwargs['type'] = _custom_wrap_type(type_value)
         # For store_`bool`, the default is the negation
         elif kwargs.get('action') == 'store_true':
             kwargs['default'] = _custom_wrap_default_value(False)
@@ -279,6 +282,15 @@ class MixinArgumentDecorator(
                     "Skipping mixin key '{mixin_key}' which was passed "
                     'explicitly as a command line argument'
                     .format_map(locals()))
+
+
+def _custom_wrap_type(original_type):
+    def _impl(value):
+        is_default = is_default_value(value)
+        res = original_type(value)
+        if is_default:
+            res = _custom_wrap_default_value(value)
+        return res
 
 
 def _custom_wrap_default_value(value):


### PR DESCRIPTION
If an argument default is a `str` type and the argument is also given an explicit `type`, the conversion will be performed on the default during parsing, which strips the wrapper.

This change wraps the type conversion to re-add the wrapper to the converted value if the original value was wrapped as well.

Closes #45 