### PR TITLE
Drop unnecessary scope qualifiers to please flake8

### DIFF
--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -51,7 +51,6 @@ VERB_BLOCKLIST = {
 
 if sys.version_info[:2] >= (3, 7):
     def __getattr__(name):
-        global VERB_BLOCKLIST
         if name == 'VERB_BLACKLIST':
             warnings.warn(
                 "'colcon_mixin.mixin.mixin_argument.VERB_BLACKLIST' has been "
@@ -121,8 +120,6 @@ class MixinArgumentDecorator(
 
     def parse_args(self, *args, **kwargs):
         """Add mixin argument for each parser."""
-        global VERB_BLOCKLIST
-
         # mapping of all "leaf" verbs to parsers
         def collect_parsers_by_verb(root, parsers, parent_verbs=()):
             found_any = False

--- a/colcon_mixin/mixin/repository.py
+++ b/colcon_mixin/mixin/repository.py
@@ -26,7 +26,6 @@ def get_repositories():
 
     :rtype: dict
     """
-    global mixin_repositories_file
     if not mixin_repositories_file.exists():
         return {}
     if mixin_repositories_file.is_dir():
@@ -46,7 +45,6 @@ def set_repositories(repositories):
     """
     assert isinstance(repositories, dict), \
         'The passed repositories should be a dictionary'
-    global mixin_repositories_file
     data = yaml.dump(repositories, default_flow_style=False)
     os.makedirs(str(mixin_repositories_file.parent), exist_ok=True)
     with mixin_repositories_file.open('w') as h:

--- a/colcon_mixin/subverb/show.py
+++ b/colcon_mixin/subverb/show.py
@@ -9,7 +9,6 @@ from colcon_mixin.subverb import MixinSubverbExtensionPoint
 def _get_mixin_name_completer(verb_key, mixins_by_verb):
     def mixin_name_completer(prefix, **kwargs):
         """Callable returning a list of mixin names."""
-        nonlocal mixins_by_verb
         args = kwargs.get('parsed_args', {})
         verb = getattr(args, verb_key)
         key = tuple(verb.split('.'))

--- a/test/test_spell_check.py
+++ b/test/test_spell_check.py
@@ -10,7 +10,6 @@ spell_check_words_path = Path(__file__).parent / 'spell_check.words'
 
 @pytest.fixture(scope='module')
 def known_words():
-    global spell_check_words_path
     return spell_check_words_path.read_text().splitlines()
 
 


### PR DESCRIPTION
These variables are not assigned to, and so the scope qualifiers are not necessary and may be misleading.