### PR TITLE
Use user's ~/.netrc for accessing mixin repositories

### DIFF
--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -11,6 +11,7 @@ iterdir
 linter
 mixins
 nargs
+netrc
 noqa
 pathlib
 plugin


### PR DESCRIPTION
Recent changes to GitHub raw content availability have made it more desirable to support authenticated requests to externally hosted content. Rather than adding specific logic for GitHub's authorization mechanisms, we can leverage the widely used .netrc format for adding an authorization header to our web requests.

As an example, a GitHub classic PAT with sufficient scopes can be configured and automatically used with a `~/.netrc` like this:
```
machine raw.githubusercontent.com password gbp_XXXXXXXXX
```

Note that this scheme works for `raw.githubusercontent.com`, but may not work for `github.com` URLs (even when they redirect to `raw.githubusercontent.com`). Also worth noting is that .netrc files are implicitly used by the widely-used `requests` Python package, so there is precedent for their use in this context.

This change doesn't introduce any new dependencies, but does change default behavior.