### PR TITLE
Added base pre-commit hooks for whitespaces and trailing newlines.

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,25 @@
+---
+name: Linting
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+
+  pre-commit:
+    name: pre-commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: 3.12
+
+      - name: Run pre-commit
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+---
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: trailing-whitespace


### PR DESCRIPTION
## Basic Info

| Info | Result |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |

## Description of contribution

- I have added the following hooks as part of the pre-commit:
   * `end-of-file-fixer`
   * `mixed-line-ending`
   * `trailing-whitespace`

   This prevents empty whitespace and additional newlines from registering as a separate commit during development.
    
## Description of testing done

* Ran the pre-commit to verify changes

   ```bash
   pre-commit run --all
   ```