### PR TITLE
Remove warnings during build and ignore built artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 __pycache__/
 /*.egg-info/
-dist/
+/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 /*.egg-info/
+dist/

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ classifiers =
     Operating System :: POSIX
     Programming Language :: Python
     Topic :: Software Development :: Build Tools
-license = Apache License, Version 2.0
+license = Apache-2.0
 description = Extension for colcon to read CLI mixins from files.
 long_description = file: README.rst
 keywords = colcon

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     Development Status :: 3 - Alpha
     Environment :: Plugins
     Intended Audience :: Developers
-    License :: OSI Approved :: Apache Software License
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX


### PR DESCRIPTION
## Description of contribution in a few bullet points
* Official Python packaging documentation now recommends using [SPDX expressions](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license) instead of Trove's classifiers, and resolves the following warning:

   ```text
   dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
   !!

           ********************************************************************************
           Please consider removing the following classifiers in favor of a SPDX license expression:
   
           License :: OSI Approved :: MIT License
   
           See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
           ********************************************************************************
   !!
   ```
* Added ignores for the `dist/` directory to avoid built artifacts from registering as commits.
   
## Description of how this change was tested
   
* No warnings when invoking `python3 -m build`.
   

