### PR TITLE
Deprecate colcon_mixin.mixin.repository.mixin_repositories_file

### DIFF
--- a/colcon_mixin/mixin/repository.py
+++ b/colcon_mixin/mixin/repository.py
@@ -3,10 +3,12 @@
 
 import os
 import socket
+import sys
 import time
 from urllib.error import HTTPError
 from urllib.error import URLError
 from urllib.request import urlopen
+import warnings
 
 from colcon_core.location import get_config_path
 from colcon_core.logging import colcon_logger
@@ -16,8 +18,30 @@ import yaml
 
 logger = colcon_logger.getChild(__name__)
 
-"""The path of the yaml file describing the mixin repositories."""
-mixin_repositories_file = get_config_path() / 'mixin_repositories.yaml'
+
+def get_mixin_repositories_file():
+    """
+    Get the path of the yaml file describing the mixin repositories.
+
+    :rtype: Path
+    """
+    return get_config_path() / 'mixin_repositories.yaml'
+
+
+if sys.version_info[:2] >= (3, 7):
+    def __getattr__(name):
+        if name == 'mixin_repositories_file':
+            warnings.warn(
+                "'colcon_mixin.mixin.repository.mixin_repositories_file' has "
+                "been deprecated, use 'colcon_mixin.mixin.repository."
+                "get_mixin_repositories_file()' instead", stacklevel=2)
+            return get_mixin_repositories_file()
+        raise AttributeError(
+            "module '%s' has no attribute '%s'" % (__name__, name))
+else:
+    # for backward compatibility but without a deprecation warning on usage
+    """The path of the yaml file describing the mixin repositories."""
+    mixin_repositories_file = get_mixin_repositories_file()
 
 
 def get_repositories():
@@ -26,6 +50,7 @@ def get_repositories():
 
     :rtype: dict
     """
+    mixin_repositories_file = get_mixin_repositories_file()
     if not mixin_repositories_file.exists():
         return {}
     if mixin_repositories_file.is_dir():
@@ -45,6 +70,7 @@ def set_repositories(repositories):
     """
     assert isinstance(repositories, dict), \
         'The passed repositories should be a dictionary'
+    mixin_repositories_file = get_mixin_repositories_file()
     data = yaml.dump(repositories, default_flow_style=False)
     os.makedirs(str(mixin_repositories_file.parent), exist_ok=True)
     with mixin_repositories_file.open('w') as h:

--- a/colcon_mixin/mixin/repository.py
+++ b/colcon_mixin/mixin/repository.py
@@ -37,7 +37,7 @@ if sys.version_info[:2] >= (3, 7):
                 "get_mixin_repositories_file()' instead", stacklevel=2)
             return get_mixin_repositories_file()
         raise AttributeError(
-            "module '%s' has no attribute '%s'" % (__name__, name))
+            f"module '{__name__}' has no attribute '{name}'")
 else:
     # for backward compatibility but without a deprecation warning on usage
     """The path of the yaml file describing the mixin repositories."""

--- a/colcon_mixin/mixin/repository.py
+++ b/colcon_mixin/mixin/repository.py
@@ -40,7 +40,6 @@ if sys.version_info[:2] >= (3, 7):
             f"module '{__name__}' has no attribute '{name}'")
 else:
     # for backward compatibility but without a deprecation warning on usage
-    """The path of the yaml file describing the mixin repositories."""
     mixin_repositories_file = get_mixin_repositories_file()
 
 

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -26,6 +26,7 @@ subparsers
 subverb
 subverbs
 thomas
+unittest
 urllib
 urlopen
 urls

--- a/test/test_deprecations.py
+++ b/test/test_deprecations.py
@@ -1,0 +1,47 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+from pathlib import Path
+import sys
+from unittest.mock import patch
+
+import pytest
+
+
+def test_verb_blacklist():
+    if sys.version_info < (3, 7):
+        # Older Python doesn't support the syntax to emit this warning
+        from colcon_mixin.mixin.mixin_argument \
+            import VERB_BLACKLIST  # noqa: F401
+    else:
+        with pytest.warns(UserWarning, match='deprecated'):
+            from colcon_mixin.mixin.mixin_argument \
+                import VERB_BLACKLIST  # noqa: F401
+
+        with pytest.warns(UserWarning, match='deprecated'):
+            import colcon_mixin.mixin.mixin_argument
+            colcon_mixin.mixin.mixin_argument.VERB_BLACKLIST
+
+    with pytest.raises(ImportError):
+        from colcon_mixin.mixin.mixin_argument \
+            import does_not_exist  # noqa: F401
+
+
+@patch('colcon_core.location.get_config_path', Path.cwd)
+def test_mixin_repositories_file():
+    if sys.version_info < (3, 7):
+        # Older Python doesn't support the syntax to emit this warning
+        from colcon_mixin.mixin.repository \
+            import mixin_repositories_file  # noqa: F401
+    else:
+        with pytest.warns(UserWarning, match='deprecated'):
+            from colcon_mixin.mixin.repository \
+                import mixin_repositories_file  # noqa: F401
+
+        with pytest.warns(UserWarning, match='deprecated'):
+            import colcon_mixin.mixin.repository
+            colcon_mixin.mixin.repository.mixin_repositories_file
+
+    with pytest.raises(ImportError):
+        from colcon_mixin.mixin.repository \
+            import does_not_exist  # noqa: F401

--- a/test/test_deprecations.py
+++ b/test/test_deprecations.py
@@ -45,3 +45,8 @@ def test_mixin_repositories_file():
     with pytest.raises(ImportError):
         from colcon_mixin.mixin.repository \
             import does_not_exist  # noqa: F401
+
+    with pytest.raises(AttributeError, match='has no attribute'):
+        import colcon_mixin.mixin.repository
+        colcon_mixin.mixin.repository.does_not_exist
+

--- a/test/test_deprecations.py
+++ b/test/test_deprecations.py
@@ -49,4 +49,3 @@ def test_mixin_repositories_file():
     with pytest.raises(AttributeError, match='has no attribute'):
         import colcon_mixin.mixin.repository
         colcon_mixin.mixin.repository.does_not_exist
-


### PR DESCRIPTION
Importing this module currently requires that colcon has already initialized the config location, which makes testing difficult and produces undesired behavior if the location changes during runtime. Following the behavior of `colcon_mixin.mixin.get_mixin_path`, we should use a "getter" pattern here.

This change also adds a test for an existing deprecation in this package.