### PR TITLE
Enable show subverb to print yamllint compliant YAML.

### DIFF
--- a/colcon_mixin/subverb/show.py
+++ b/colcon_mixin/subverb/show.py
@@ -4,6 +4,7 @@
 from colcon_core.plugin_system import satisfies_version
 from colcon_mixin.mixin import get_mixins
 from colcon_mixin.subverb import MixinSubverbExtensionPoint
+import yaml
 
 
 def _get_mixin_name_completer(verb_key, mixins_by_verb):
@@ -14,6 +15,14 @@ def _get_mixin_name_completer(verb_key, mixins_by_verb):
         key = tuple(verb.split('.'))
         return mixins_by_verb.get(key, {}).keys()
     return mixin_name_completer
+
+
+class IndentDumper(yaml.Dumper):
+    """Custom YAML dumper with yamllint compliant indentation."""
+
+    def increase_indent(self, flow=False, indentless=False):
+        """Override to disable indentless option."""
+        return super(IndentDumper, self).increase_indent(flow, False)
 
 
 class ShowMixinSubverb(MixinSubverbExtensionPoint):
@@ -47,32 +56,30 @@ class ShowMixinSubverb(MixinSubverbExtensionPoint):
             context.args.verb and
             tuple(context.args.verb.split('.')) not in self.mixins_by_verb
         ):
-            return "Passed verb name '{context.args.verb}' has no mixins" \
-                .format_map(locals())
+            return f"Passed verb name '{context.args.verb}' has no mixins"
+
+        output_data = {}
 
         for verb in sorted(self.mixins_by_verb.keys()):
             if context.args.verb:
                 if context.args.verb != '.'.join(verb):
                     continue
-            else:
-                verb_space = ' '.join(verb)
-                print('{verb_space}:'.format_map(locals()))
 
+            verb_key = '.'.join(verb)
             mixins = self.mixins_by_verb[verb]
-            for mixin_name in sorted(mixins.keys()):
-                if context.args.mixin_name:
-                    if context.args.mixin_name != mixin_name:
-                        continue
-                    if context.args.mixin_name not in mixins:
-                        return 'Passed mixin name ' \
-                            "'{context.args.mixin_name}' is not defined" \
-                            .format_map(locals())
 
-                else:
-                    print('- {mixin_name}'.format_map(locals()))
-                mixin_value = mixins[mixin_name]
-                for arg_key, arg_value in mixin_value.items():
-                    indent = '  ' if context.args.mixin_name is None else ''
-                    print(
-                        '{indent}{arg_key}: {arg_value}'
-                        .format_map(locals()))
+            # Filter mixins if specific mixin name is requested
+            if context.args.mixin_name:
+                if context.args.mixin_name not in mixins:
+                    return (
+                        f'Passed mixin name "{context.args.mixin_name}"'
+                        ' is not defined'
+                    )
+                output_data[verb_key] = {
+                    context.args.mixin_name: mixins[context.args.mixin_name]
+                }
+            else:
+                output_data[verb_key] = mixins
+
+        print(yaml.dump(output_data, Dumper=IndentDumper,
+                        sort_keys=True, explicit_start=True), end='')

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -7,6 +7,7 @@ blocklist
 colcon
 completers
 defaultdict
+indentless
 iterdir
 linter
 mixins
@@ -31,3 +32,4 @@ urllib
 urlopen
 urls
 yaml
+yamllint


### PR DESCRIPTION
## Basic Info

| Info | Result |
| ------ | ----------- |
| Primary OS tested on | Ubuntu |

## Description of contribution in a few bullet points

* Enabled `colcon mixin show` to print in a YAML that is compliant with the onboard `yamllint` linter.
* Included a custom `IndentDumper` so that `yaml.dump` would print indentation that is suited to the linter.
* Reformatted all the strings to f-strings for brevity.

## Description of how this change was tested

* Add the mixins from the sample [colcon-mixin-repository](https://github.com/colcon/colcon-mixin-repository):

   ```bash
   colcon mixin add default https://raw.githubusercontent.com/colcon/colcon-mixin-repository/master/index.yaml
   colcon mixin update default
   ```
* Without this change, the `show` subverb would yield the following:

   ```bash
   colcon mixin show test
   ```
   ```yaml
   - coverage-pytest
     pytest-args: ['--cov-report=term']
     pytest-with-coverage: True
   - linters-only
     ctest-args: ['-L', 'linter']
     pytest-args: ['-m', 'linter']
   - linters-skip
     ctest-args: ['-LE', 'linter']
     pytest-args: ['-m', 'not linter']
   - memcheck
     ctest-args: ['-D', 'ExperimentalMemCheck']
   ```
   This is printed in a non-standard format, and is not a YAML file.
   
* After incorporating this PR, the output is as follows:

   ```yaml
   ---
   test:
     coverage-pytest:
       pytest-args:
         - --cov-report=term
       pytest-with-coverage: true
     linters-only:
       ctest-args:
         - -L
         - linter
       pytest-args:
         - -m
         - linter
     linters-skip:
       ctest-args:
         - -LE
         - linter
       pytest-args:
         - -m
         - not linter
     memcheck:
       ctest-args:
         - -D
         - ExperimentalMemCheck
   ```
* You can verify the sanctity of this output by testing it against `yamllint`:

   ```bash
   colcon mixin show test > test.yaml && yamllint test.yaml 
   ```
   
   
   
   
   

   



   
