### PR TITLE
Add support for mixin composition

### DIFF
--- a/colcon_mixin/mixin/__init__.py
+++ b/colcon_mixin/mixin/__init__.py
@@ -125,3 +125,60 @@ def add_mixins(mixin_path, mixins_by_verb):
                     'with the same name' %
                     (name, mixin_path.absolute()))
             mixins_by_verb[verb_key][name] = args
+
+
+def resolve_mixin(verb_key, mixin_name, mixins_by_verb, _resolving=None):
+    """
+    Resolve a mixin by flattening its composed references.
+
+    Referenced mixins are resolved left-to-right, then the mixin's own
+    arguments are merged on top. Precedence matches the CLI behavior of
+    _update_args: lists use prepending order, first scalar wins between
+    references, own scalars always override.
+
+    :param tuple verb_key: The verb tuple
+    :param str mixin_name: The name of the mixin to resolve
+    :param dict mixins_by_verb: The full mixin collection
+    :param set _resolving: Internal set for cycle detection
+    :raises RuntimeError: On cycles or missing references
+    :rtype: dict
+    """
+    if _resolving is None:
+        _resolving = set()
+
+    verb_mixins = mixins_by_verb.get(verb_key, {})
+    if mixin_name not in verb_mixins:
+        raise RuntimeError(
+            "Mixin '%s' referenced in composition does not exist for "
+            "verb '%s'" % (mixin_name, '.'.join(verb_key)))
+
+    if mixin_name in _resolving:
+        raise RuntimeError(
+            'Cycle detected in mixin composition: %s' % mixin_name)
+
+    mixin_def = verb_mixins[mixin_name]
+    refs = mixin_def.get('mixin', [])
+    if not isinstance(refs, list):
+        refs = []
+
+    _resolving.add(mixin_name)
+    resolved = {}
+    for ref in refs:
+        ref_args = resolve_mixin(verb_key, ref, mixins_by_verb, _resolving)
+        for k, v in ref_args.items():
+            if k not in resolved:
+                resolved[k] = v
+            elif isinstance(resolved[k], list) and isinstance(v, list):
+                resolved[k] = v + resolved[k]
+    _resolving.discard(mixin_name)
+
+    for k, v in mixin_def.items():
+        if k == 'mixin':
+            continue
+        if k not in resolved:
+            resolved[k] = v
+        elif isinstance(resolved[k], list) and isinstance(v, list):
+            resolved[k] = v + resolved[k]
+        else:
+            resolved[k] = v
+    return resolved

--- a/colcon_mixin/mixin/__init__.py
+++ b/colcon_mixin/mixin/__init__.py
@@ -127,6 +127,37 @@ def add_mixins(mixin_path, mixins_by_verb):
             mixins_by_verb[verb_key][name] = args
 
 
+def _get_mixin_references(verb_key, mixin_name, mixin_def):
+    """
+    Validate and return the composed mixin references for a mixin.
+
+    :param tuple verb_key: The verb tuple
+    :param str mixin_name: The name of the mixin to inspect
+    :param object mixin_def: The raw mixin definition
+    :raises RuntimeError: On malformed mixin definitions
+    :rtype: list
+    """
+    context = '.'.join(verb_key)
+    if not isinstance(mixin_def, dict):
+        raise RuntimeError(
+            "Mixin '%s' for verb '%s' must define a dictionary of arguments" %
+            (mixin_name, context))
+
+    refs = mixin_def.get('mixin', [])
+    if not isinstance(refs, list):
+        raise RuntimeError(
+            "Mixin '%s' for verb '%s' defines reserved key 'mixin' with "
+            'invalid type, expected a list' % (mixin_name, context))
+
+    for ref in refs:
+        if not isinstance(ref, str):
+            raise RuntimeError(
+                "Mixin '%s' for verb '%s' defines reserved key 'mixin' "
+                'with non-string entry %r' % (mixin_name, context, ref))
+
+    return refs
+
+
 def resolve_mixin(verb_key, mixin_name, mixins_by_verb, _resolving=None):
     """
     Resolve a mixin by flattening its composed references.
@@ -157,28 +188,28 @@ def resolve_mixin(verb_key, mixin_name, mixins_by_verb, _resolving=None):
             'Cycle detected in mixin composition: %s' % mixin_name)
 
     mixin_def = verb_mixins[mixin_name]
-    refs = mixin_def.get('mixin', [])
-    if not isinstance(refs, list):
-        refs = []
+    refs = _get_mixin_references(verb_key, mixin_name, mixin_def)
 
     _resolving.add(mixin_name)
-    resolved = {}
-    for ref in refs:
-        ref_args = resolve_mixin(verb_key, ref, mixins_by_verb, _resolving)
-        for k, v in ref_args.items():
+    try:
+        resolved = {}
+        for ref in refs:
+            ref_args = resolve_mixin(verb_key, ref, mixins_by_verb, _resolving)
+            for k, v in ref_args.items():
+                if k not in resolved:
+                    resolved[k] = v
+                elif isinstance(resolved[k], list) and isinstance(v, list):
+                    resolved[k] = v + resolved[k]
+
+        for k, v in mixin_def.items():
+            if k == 'mixin':
+                continue
             if k not in resolved:
                 resolved[k] = v
             elif isinstance(resolved[k], list) and isinstance(v, list):
                 resolved[k] = v + resolved[k]
-    _resolving.discard(mixin_name)
-
-    for k, v in mixin_def.items():
-        if k == 'mixin':
-            continue
-        if k not in resolved:
-            resolved[k] = v
-        elif isinstance(resolved[k], list) and isinstance(v, list):
-            resolved[k] = v + resolved[k]
-        else:
-            resolved[k] = v
-    return resolved
+            else:
+                resolved[k] = v
+        return resolved
+    finally:
+        _resolving.discard(mixin_name)

--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -24,6 +24,7 @@ from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_mixin.mixin import add_mixins
 from colcon_mixin.mixin import get_mixins
+from colcon_mixin.mixin import resolve_mixin
 
 logger = colcon_logger.getChild(__name__)
 
@@ -187,7 +188,11 @@ class MixinArgumentDecorator(
                     self._parser.error(
                         "Mixin '{mixin}' is not available for '{context}'"
                         .format_map(locals()))
-                mixin_args = mixins[mixin]
+                try:
+                    mixin_args = resolve_mixin(
+                        args.mixin_verb, mixin, mixins_by_verb)
+                except RuntimeError as e:
+                    self._parser.error(str(e))
                 logger.debug(
                     "Using mixin '{mixin}': {mixin_args}".format_map(locals()))
                 self._update_args(args, mixin_args, '.'.join(args.mixin_verb))

--- a/test/test_mixin_composition.py
+++ b/test/test_mixin_composition.py
@@ -1,9 +1,12 @@
 # Copyright 2026 Open Robotics
 # Licensed under the Apache License, Version 2.0
 
+import argparse
 from collections import defaultdict
+from unittest.mock import patch
 
 from colcon_mixin.mixin import resolve_mixin
+from colcon_mixin.mixin.mixin_argument import MixinArgumentDecorator
 import pytest
 
 
@@ -12,6 +15,15 @@ def _make_mixins(mixin_dict):
     mbv = defaultdict(dict)
     mbv[('build',)] = dict(mixin_dict)
     return mbv
+
+
+def _make_argument_parser():
+    parser = MixinArgumentDecorator(argparse.ArgumentParser())
+    subparsers = parser.add_subparsers(dest='verb')
+    build = subparsers.add_parser('build')
+    build.add_argument('--build-base')
+    build.add_argument('--args', nargs='*')
+    return parser
 
 
 def test_resolve_no_composition():
@@ -36,6 +48,23 @@ def test_resolve_simple():
     assert result == {
         'args': ['--flag-a'],
         'build-base': '/tmp/build',
+    }
+
+
+def test_resolve_nested_composition():
+    """Nested references are flattened recursively before own args apply."""
+    mbv = _make_mixins({
+        'base': {'args': ['base']},
+        'extra': {'args': ['extra']},
+        'base-extra': {'mixin': ['base', 'extra']},
+        'combined': {
+            'mixin': ['base-extra'],
+            'args': ['combined'],
+        },
+    })
+    result = resolve_mixin(('build',), 'combined', mbv)
+    assert result == {
+        'args': ['combined', 'extra', 'base'],
     }
 
 
@@ -96,3 +125,87 @@ def test_resolve_missing_reference():
     })
     with pytest.raises(RuntimeError, match='does not exist'):
         resolve_mixin(('build',), 'broken', mbv)
+
+
+@pytest.mark.parametrize(
+    ('mixin_def', 'error_match'),
+    [
+        ({'mixin': 'base'}, 'expected a list'),
+        ({'mixin': ['base', 1]}, 'non-string entry'),
+    ],
+)
+def test_resolve_invalid_mixin_definition(mixin_def, error_match):
+    """Malformed 'mixin' definitions raise a RuntimeError."""
+    mbv = _make_mixins({
+        'broken': mixin_def,
+    })
+    with pytest.raises(RuntimeError, match=error_match):
+        resolve_mixin(('build',), 'broken', mbv)
+
+
+@patch('colcon_mixin.mixin.mixin_argument.get_mixins')
+def test_parse_args_with_composed_mixin(get_mixins):
+    """Parser integration applies composed mixins before explicit CLI args."""
+    get_mixins.return_value = _make_mixins({
+        'base': {
+            'build-base': '/tmp/base',
+            'args': ['base'],
+        },
+        'extra': {'args': ['extra']},
+        'combo': {'mixin': ['base', 'extra']},
+    })
+    parser = _make_argument_parser()
+
+    args = parser.parse_args([
+        'build',
+        '--mixin', 'combo',
+        '--build-base', '/tmp/cli',
+        '--args', 'cli',
+    ])
+
+    assert args.build_base == '/tmp/cli'
+    assert args.args == ['extra', 'base', 'cli']
+
+
+@pytest.mark.parametrize(
+    ('mixin_name', 'mixins', 'error_match'),
+    [
+        (
+            'broken-type',
+            {
+                'broken-type': {'mixin': 'base'},
+                'base': {'args': ['base']},
+            },
+            'expected a list',
+        ),
+        (
+            'missing-ref',
+            {'missing-ref': {'mixin': ['missing']}},
+            'does not exist',
+        ),
+        (
+            'cycle-a',
+            {
+                'cycle-a': {'mixin': ['cycle-b']},
+                'cycle-b': {'mixin': ['cycle-a']},
+            },
+            'Cycle detected',
+        ),
+    ],
+)
+@patch('colcon_mixin.mixin.mixin_argument.get_mixins')
+def test_parse_args_reports_composition_errors(
+    get_mixins, mixin_name, mixins, error_match
+):
+    """Parser errors surface malformed composition definitions cleanly."""
+    get_mixins.return_value = _make_mixins(mixins)
+    parser = _make_argument_parser()
+
+    with patch.object(
+        parser._parser,
+        'error',
+        side_effect=lambda message: (_ for _ in ()).throw(
+            RuntimeError(message)),
+    ):
+        with pytest.raises(RuntimeError, match=error_match):
+            parser.parse_args(['build', '--mixin', mixin_name])

--- a/test/test_mixin_composition.py
+++ b/test/test_mixin_composition.py
@@ -1,0 +1,98 @@
+# Copyright 2026 Open Robotics
+# Licensed under the Apache License, Version 2.0
+
+from collections import defaultdict
+
+from colcon_mixin.mixin import resolve_mixin
+import pytest
+
+
+def _make_mixins(mixin_dict):
+    """Build a mixins_by_verb dict for verb ('build',)."""
+    mbv = defaultdict(dict)
+    mbv[('build',)] = dict(mixin_dict)
+    return mbv
+
+
+def test_resolve_no_composition():
+    """Mixin without a 'mixin' key returns its args unchanged."""
+    mbv = _make_mixins({
+        'debug': {'args': ['--flag-a']},
+    })
+    result = resolve_mixin(('build',), 'debug', mbv)
+    assert result == {'args': ['--flag-a']}
+
+
+def test_resolve_simple():
+    """Mixin referencing another gets the referenced args plus its own."""
+    mbv = _make_mixins({
+        'base': {'args': ['--flag-a']},
+        'composed': {
+            'mixin': ['base'],
+            'build-base': '/tmp/build',
+        },
+    })
+    result = resolve_mixin(('build',), 'composed', mbv)
+    assert result == {
+        'args': ['--flag-a'],
+        'build-base': '/tmp/build',
+    }
+
+
+def test_resolve_list_concatenation():
+    """List args use prepending order, matching CLI --mixin."""
+    mbv = _make_mixins({
+        'base': {'args': ['--flag-a']},
+        'extra': {
+            'mixin': ['base'],
+            'args': ['--flag-b'],
+        },
+    })
+    result = resolve_mixin(('build',), 'extra', mbv)
+    # own args go first, matching _update_args behavior
+    assert result == {
+        'args': ['--flag-b', '--flag-a'],
+    }
+
+
+def test_resolve_scalar_own_overrides_ref():
+    """Own scalar args override referenced mixin's scalar args."""
+    mbv = _make_mixins({
+        'base': {'build-base': '/tmp/base'},
+        'override': {
+            'mixin': ['base'],
+            'build-base': '/tmp/override',
+        },
+    })
+    result = resolve_mixin(('build',), 'override', mbv)
+    assert result == {'build-base': '/tmp/override'}
+
+
+def test_resolve_scalar_first_ref_wins():
+    """Between references, first scalar wins (matches CLI behavior)."""
+    mbv = _make_mixins({
+        'a': {'build-base': '/from-a'},
+        'b': {'build-base': '/from-b'},
+        'composed': {'mixin': ['a', 'b']},
+    })
+    result = resolve_mixin(('build',), 'composed', mbv)
+    assert result == {'build-base': '/from-a'}
+
+
+def test_resolve_cycle_detection():
+    """Cyclic references raise RuntimeError."""
+    mbv = _make_mixins({
+        'a': {'mixin': ['b'], 'x': 1},
+        'b': {'mixin': ['a'], 'y': 2},
+    })
+    with pytest.raises(RuntimeError, match='Cycle detected'):
+        resolve_mixin(('build',), 'a', mbv)
+
+
+def test_resolve_missing_reference():
+    """Reference to a non-existent mixin raises RuntimeError."""
+    mbv = _make_mixins({
+        'broken': {'mixin': ['nonexistent']},
+    })
+    with pytest.raises(RuntimeError, match='does not exist'):
+        resolve_mixin(('build',), 'broken', mbv)


### PR DESCRIPTION
Allows mixins to reference other mixins via a reserved `mixin` key. Resolves https://github.com/colcon/colcon-mixin/issues/39.

A mixin definition can now include a list of other mixin names to compose:

```yaml
build:
  debug:
    cmake-args: ["-DCMAKE_BUILD_TYPE=Debug"]
  asan:
    cmake-args: ["-DSANITIZE_ADDRESS=ON"]
  debug-asan:
    mixin: ["debug", "asan"]
    cmake-args: ["-DEXTRA_FLAG=1"]
```

Using --mixin debug-asan resolves all referenced mixins recursively before applying the mixin's own arguments. Precedence matches existing CLI --mixin behavior:
- Lists are prepended (later mixin values come first, matching _update_args)
- Scalars between references use first-write-wins (matching how _update_args skips already-set scalars)
- Own args always override referenced values

Also adds validation and tests for:

- missing references
- composition cycles
- invalid mixin definitions
- parser-level composed mixin application and error paths

Existing mixin files without a mixin key are unaffected.