### PR TITLE
Support mixins referencing other mixins via a reserved 'mixin' key

### DIFF
--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -24,6 +24,10 @@ from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_mixin.mixin import add_mixins
 from colcon_mixin.mixin import get_mixins
+from colcon_mixin.mixin.order import CircularMixinError
+from colcon_mixin.mixin.order import compute_application_order
+from colcon_mixin.mixin.order import InvalidMixinError
+from colcon_mixin.mixin.order import MissingMixinError
 
 logger = colcon_logger.getChild(__name__)
 
@@ -181,23 +185,36 @@ class MixinArgumentDecorator(
         # update args based on selected mixins
         if 'mixin_verb' in args:
             mixins = mixins_by_verb.get(args.mixin_verb, {})
+            context = '.'.join(args.mixin_verb)
             # validate the requested mixins in the order given on the command
             # line so an error reports the first unavailable mixin
             for mixin in args.mixin or ():
                 if mixin not in mixins:
-                    context = '.'.join(args.mixin_verb)
                     self._parser.error(
                         "Mixin '{mixin}' is not available for '{context}'"
                         .format_map(locals()))
+            # expand each requested mixin into the full list of mixins to
+            # apply: a mixin may reference other mixins through a 'mixin' key,
+            # which are applied first so the requesting mixin can override
+            # them (depth-first post-order, see colcon_mixin.mixin.order)
+            application_order = []
+            for mixin in args.mixin or ():
+                try:
+                    application_order += compute_application_order(
+                        mixins, mixin)
+                except (
+                    CircularMixinError, InvalidMixinError, MissingMixinError,
+                ) as e:
+                    self._parser.error(str(e))
             # apply the mixins in reverse order: since _update_args() handles
             # each mixin by prepending its list values, iterating in reverse
-            # makes the resulting list follow the order the mixins were given
-            # on the command line while keeping any explicit command line
-            for mixin in reversed(args.mixin or ()):
+            # makes the resulting list follow the computed application order
+            # while keeping any explicit command line arguments last
+            for mixin in reversed(application_order):
                 mixin_args = mixins[mixin]
                 logger.debug(
                     "Using mixin '{mixin}': {mixin_args}".format_map(locals()))
-                self._update_args(args, mixin_args, '.'.join(args.mixin_verb))
+                self._update_args(args, mixin_args, context)
 
         # undo default value wrapping injected in the add_argument() method
         for k, v in args.__dict__.items():
@@ -261,6 +278,10 @@ class MixinArgumentDecorator(
     def _update_args(self, args, mixin_args, context):
         destinations = self.get_destinations()
         for mixin_key, mixin_value in mixin_args.items():
+            if mixin_key == 'mixin':
+                # reserved metadata key listing referenced mixins; it is not
+                # an argument to overlay (see colcon_mixin.mixin.order)
+                continue
             if mixin_key not in destinations:
                 logger.warning(
                     "Mixin key '{mixin_key}' is not a valid argument for "

--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -193,7 +193,6 @@ class MixinArgumentDecorator(
             # each mixin by prepending its list values, iterating in reverse
             # makes the resulting list follow the order the mixins were given
             # on the command line while keeping any explicit command line
-            # arguments last (see #40)
             for mixin in reversed(args.mixin or ()):
                 mixin_args = mixins[mixin]
                 logger.debug(

--- a/colcon_mixin/mixin/mixin_argument.py
+++ b/colcon_mixin/mixin/mixin_argument.py
@@ -181,12 +181,20 @@ class MixinArgumentDecorator(
         # update args based on selected mixins
         if 'mixin_verb' in args:
             mixins = mixins_by_verb.get(args.mixin_verb, {})
+            # validate the requested mixins in the order given on the command
+            # line so an error reports the first unavailable mixin
             for mixin in args.mixin or ():
                 if mixin not in mixins:
                     context = '.'.join(args.mixin_verb)
                     self._parser.error(
                         "Mixin '{mixin}' is not available for '{context}'"
                         .format_map(locals()))
+            # apply the mixins in reverse order: since _update_args() handles
+            # each mixin by prepending its list values, iterating in reverse
+            # makes the resulting list follow the order the mixins were given
+            # on the command line while keeping any explicit command line
+            # arguments last (see #40)
+            for mixin in reversed(args.mixin or ()):
                 mixin_args = mixins[mixin]
                 logger.debug(
                     "Using mixin '{mixin}': {mixin_args}".format_map(locals()))

--- a/colcon_mixin/mixin/order.py
+++ b/colcon_mixin/mixin/order.py
@@ -1,0 +1,69 @@
+# Copyright 2026 Innocent Pious
+# Licensed under the Apache License, Version 2.0
+
+"""Compute the order in which mixins referencing other mixins are applied."""
+
+
+class CircularMixinError(Exception):
+    """Raised when the mixin reference graph contains a cycle."""
+
+
+class MissingMixinError(Exception):
+    """Raised when a referenced mixin name does not exist."""
+
+
+class InvalidMixinError(Exception):
+    """Raised when a 'mixin' key is not a list of strings."""
+
+
+def _read_references(mixins, name):
+    refs = mixins[name].get('mixin', [])
+    if not isinstance(refs, list) or not all(
+        isinstance(ref, str) for ref in refs
+    ):
+        raise InvalidMixinError(
+            "Mixin '{name}' has an invalid 'mixin' key: expected a list of "
+            'strings'.format_map(locals()))
+    return refs
+
+
+def compute_application_order(mixins, requested):
+    """Return the mixins to apply for a requested mixin, dependencies first.
+
+    A mixin may reference other mixins through a 'mixin' key. References are
+    ordered before the mixin that references them (depth-first, post-order),
+    so the referencing mixin is applied last and can override them. A mixin
+    reached through several paths is applied once per path to keep
+    last-applied-wins semantics, so duplicates in the result are intentional.
+
+    :raises CircularMixinError: on a circular reference.
+    :raises MissingMixinError: if a referenced mixin does not exist.
+    :raises InvalidMixinError: if a 'mixin' key is malformed.
+    """
+    order = []
+    stack_path = []  # names on the active recursion path, for cycle detection
+
+    def visit(name, referrer):
+        if name not in mixins:
+            if referrer is None:
+                raise MissingMixinError(
+                    "Requested mixin '{name}' does not exist"
+                    .format_map(locals()))
+            raise MissingMixinError(
+                "Mixin '{referrer}' references unknown mixin '{name}'"
+                .format_map(locals()))
+
+        if name in stack_path:
+            path = ' -> '.join(stack_path + [name])
+            raise CircularMixinError(
+                'Circular mixin reference: {path}'.format_map(locals()))
+
+        refs = _read_references(mixins, name)
+        stack_path.append(name)
+        for ref in refs:
+            visit(ref, name)
+        stack_path.pop()
+        order.append(name)
+
+    visit(requested, None)
+    return order

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -4,6 +4,8 @@ argparse
 basenames
 basepath
 blocklist
+capsys
+cmake
 colcon
 completers
 defaultdict
@@ -17,6 +19,7 @@ plugin
 prepending
 pydocstyle
 pytest
+readouterr
 rtype
 scspell
 setuptools

--- a/test/test_mixin_argument.py
+++ b/test/test_mixin_argument.py
@@ -20,6 +20,26 @@ SCALAR_MIXINS = {
 }
 
 
+NESTED_MIXINS = {
+    'base': {'cmake-args': ['FOO=BASE']},
+    'child': {'mixin': ['base'], 'cmake-args': ['FOO=CHILD']},
+}
+
+
+SCALAR_NESTED_MIXINS = {
+    'base': {'build-base': 'BASE'},
+    'child': {'mixin': ['base'], 'build-base': 'CHILD'},
+}
+
+
+CANONICAL_MIXINS = {
+    'A': {'mixin': ['B', 'D'], 'cmake-args': ['A']},
+    'B': {'mixin': ['C'], 'cmake-args': ['B']},
+    'C': {'mixin': ['D'], 'cmake-args': ['C']},
+    'D': {'cmake-args': ['D']},
+}
+
+
 def _parse(argv, mixins=MIXINS):
     base = argparse.ArgumentParser(prog='colcon')
     decorator = MixinArgumentDecorator(base)
@@ -88,3 +108,42 @@ def test_unavailable_mixin_reports_first(capsys):
     with pytest.raises(SystemExit):
         _parse(['build', '--mixin', 'bad', 'a'])
     assert "Mixin 'bad' is not available" in capsys.readouterr().err
+
+
+def test_referenced_mixin_applied_before_referencing():
+    args = _parse(['build', '--mixin', 'child'], NESTED_MIXINS)
+    assert args.cmake_args == ['FOO=BASE', 'FOO=CHILD']
+
+
+def test_referencing_mixin_overrides_referenced_scalar():
+    args = _parse(['build', '--mixin', 'child'], SCALAR_NESTED_MIXINS)
+    assert args.build_base == 'CHILD'
+
+
+def test_canonical_reference_graph_order():
+    # D appears twice, once per path
+    args = _parse(['build', '--mixin', 'A'], CANONICAL_MIXINS)
+    assert args.cmake_args == ['D', 'C', 'B', 'D', 'A']
+
+
+def test_nested_mixin_command_line_arguments_take_precedence():
+    args = _parse(
+        ['build', '--mixin', 'child', '--cmake-args=FOO=CLI'], NESTED_MIXINS)
+    assert args.cmake_args == ['FOO=BASE', 'FOO=CHILD', 'FOO=CLI']
+
+
+def test_circular_mixin_reference_reports_error(capsys):
+    mixins = {
+        'a': {'mixin': ['b']},
+        'b': {'mixin': ['a']},
+    }
+    with pytest.raises(SystemExit):
+        _parse(['build', '--mixin', 'a'], mixins)
+    assert 'Circular mixin reference' in capsys.readouterr().err
+
+
+def test_unknown_referenced_mixin_reports_error(capsys):
+    mixins = {'a': {'mixin': ['missing']}}
+    with pytest.raises(SystemExit):
+        _parse(['build', '--mixin', 'a'], mixins)
+    assert "unknown mixin 'missing'" in capsys.readouterr().err

--- a/test/test_mixin_argument.py
+++ b/test/test_mixin_argument.py
@@ -1,0 +1,91 @@
+# Copyright 2025 Open Source Robotics Foundation, Inc.
+# Licensed under the Apache License, Version 2.0
+
+import argparse
+from unittest.mock import patch
+
+from colcon_mixin.mixin.mixin_argument import MixinArgumentDecorator
+import pytest
+
+MIXINS = {
+    'a': {'cmake-args': ['FOO=A']},
+    'b': {'cmake-args': ['FOO=B']},
+    'c': {'cmake-args': ['FOO=C']},
+}
+
+
+SCALAR_MIXINS = {
+    'a': {'build-base': 'BASE_A'},
+    'b': {'build-base': 'BASE_B'},
+}
+
+
+def _parse(argv, mixins=MIXINS):
+    base = argparse.ArgumentParser(prog='colcon')
+    decorator = MixinArgumentDecorator(base)
+    subparsers = decorator.add_subparsers(dest='verb')
+    build = subparsers.add_parser('build')
+    build.add_argument('--cmake-args', nargs='*', default=[])
+    build.add_argument('--build-base', default='build')
+    mixins_by_verb = {('build',): mixins}
+    with patch(
+        'colcon_mixin.mixin.mixin_argument.get_mixins',
+        return_value=mixins_by_verb,
+    ):
+        return decorator.parse_args(argv)
+
+
+def test_multiple_mixins_preserve_command_line_order():
+    # regression test for issue #40: the resulting list must follow the
+    # order the mixins were given on the command line
+    args = _parse(['build', '--mixin', 'a', 'b'])
+    assert args.cmake_args == ['FOO=A', 'FOO=B']
+
+
+def test_multiple_mixins_follow_reversed_selection():
+    args = _parse(['build', '--mixin', 'b', 'a'])
+    assert args.cmake_args == ['FOO=B', 'FOO=A']
+
+
+def test_three_mixins_preserve_order():
+    args = _parse(['build', '--mixin', 'a', 'b', 'c'])
+    assert args.cmake_args == ['FOO=A', 'FOO=B', 'FOO=C']
+
+
+def test_command_line_arguments_take_precedence():
+    # explicit command line arguments must come last so they win
+    args = _parse(['build', '--mixin', 'a', 'b', '--cmake-args=FOO=CLI'])
+    assert args.cmake_args == ['FOO=A', 'FOO=B', 'FOO=CLI']
+
+
+def test_single_mixin():
+    args = _parse(['build', '--mixin', 'a'])
+    assert args.cmake_args == ['FOO=A']
+
+
+def test_no_mixin():
+    args = _parse(['build'])
+    assert args.cmake_args == []
+
+
+def test_scalar_last_listed_mixin_wins():
+    # a scalar value from a later mixin must override an earlier one
+    args = _parse(['build', '--mixin', 'a', 'b'], SCALAR_MIXINS)
+    assert args.build_base == 'BASE_B'
+
+
+def test_scalar_reversed_selection():
+    args = _parse(['build', '--mixin', 'b', 'a'], SCALAR_MIXINS)
+    assert args.build_base == 'BASE_A'
+
+
+def test_scalar_command_line_argument_take_precedence():
+    args = _parse(
+        ['build', '--mixin', 'a', 'b', '--build-base', 'CLI'], SCALAR_MIXINS)
+    assert args.build_base == 'CLI'
+
+
+def test_unavailable_mixin_reports_first(capsys):
+    with pytest.raises(SystemExit):
+        _parse(['build', '--mixin', 'bad', 'a'])
+    assert "Mixin 'bad' is not available" in capsys.readouterr().err

--- a/test/test_mixin_argument.py
+++ b/test/test_mixin_argument.py
@@ -1,4 +1,4 @@
-# Copyright 2025 Open Source Robotics Foundation, Inc.
+# Copyright 2026 Open Source Robotics Foundation, Inc.
 # Licensed under the Apache License, Version 2.0
 
 import argparse

--- a/test/test_mixin_argument.py
+++ b/test/test_mixin_argument.py
@@ -36,7 +36,6 @@ def _parse(argv, mixins=MIXINS):
 
 
 def test_multiple_mixins_preserve_command_line_order():
-    # regression test for issue #40: the resulting list must follow the
     # order the mixins were given on the command line
     args = _parse(['build', '--mixin', 'a', 'b'])
     assert args.cmake_args == ['FOO=A', 'FOO=B']

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Innocent Pious
+# Licensed under the Apache License, Version 2.0
+
+"""Tests for the mixin application-order function."""
+
+from colcon_mixin.mixin.order import CircularMixinError
+from colcon_mixin.mixin.order import compute_application_order
+from colcon_mixin.mixin.order import InvalidMixinError
+from colcon_mixin.mixin.order import MissingMixinError
+import pytest
+
+
+def test_no_mixin_key():
+    mixins = {'A': {'cmake-args': ['-DA=1']}}
+    assert compute_application_order(mixins, 'A') == ['A']
+
+
+def test_empty_mixin_list():
+    mixins = {'A': {'mixin': [], 'cmake-args': ['-DA=1']}}
+    assert compute_application_order(mixins, 'A') == ['A']
+
+
+def test_single_reference():
+    mixins = {
+        'A': {'mixin': ['B']},
+        'B': {},
+    }
+    assert compute_application_order(mixins, 'A') == ['B', 'A']
+
+
+def test_two_references_order_preserved():
+    mixins = {
+        'A': {'mixin': ['B', 'C']},
+        'B': {},
+        'C': {},
+    }
+    assert compute_application_order(mixins, 'A') == ['B', 'C', 'A']
+
+
+def test_nested_chain():
+    mixins = {
+        'A': {'mixin': ['B']},
+        'B': {'mixin': ['C']},
+        'C': {'mixin': ['D']},
+        'D': {},
+    }
+    assert compute_application_order(mixins, 'A') == ['D', 'C', 'B', 'A']
+
+
+def test_canonical_example():
+    mixins = {
+        'A': {'mixin': ['B', 'D'], 'cmake-args': ['-DA=1']},
+        'B': {'mixin': ['C'], 'cmake-args': ['-DB=1']},
+        'C': {'mixin': ['D'], 'cmake-args': ['-DC=1']},
+        'D': {'cmake-args': ['-DD=1']},
+    }
+    assert compute_application_order(mixins, 'A') == \
+        ['D', 'C', 'B', 'D', 'A']
+
+
+def test_diamond_re_application():
+    # D is reached through both B and C, so it shows up twice
+    mixins = {
+        'A': {'mixin': ['B', 'C']},
+        'B': {'mixin': ['D']},
+        'C': {'mixin': ['D']},
+        'D': {},
+    }
+    order = compute_application_order(mixins, 'A')
+    assert order == ['D', 'B', 'D', 'C', 'A']
+    assert order.count('D') == 2
+
+
+def test_self_reference_cycle():
+    mixins = {'A': {'mixin': ['A']}}
+    with pytest.raises(CircularMixinError) as exc_info:
+        compute_application_order(mixins, 'A')
+    assert 'A -> A' in str(exc_info.value)
+
+
+def test_two_node_cycle():
+    mixins = {
+        'A': {'mixin': ['B']},
+        'B': {'mixin': ['A']},
+    }
+    with pytest.raises(CircularMixinError) as exc_info:
+        compute_application_order(mixins, 'A')
+    assert 'A -> B -> A' in str(exc_info.value)
+
+
+def test_three_node_cycle():
+    mixins = {
+        'A': {'mixin': ['B']},
+        'B': {'mixin': ['C']},
+        'C': {'mixin': ['A']},
+    }
+    with pytest.raises(CircularMixinError) as exc_info:
+        compute_application_order(mixins, 'A')
+    assert 'A -> B -> C -> A' in str(exc_info.value)
+
+
+def test_missing_referenced_mixin():
+    mixins = {'A': {'mixin': ['B']}}
+    with pytest.raises(MissingMixinError) as exc_info:
+        compute_application_order(mixins, 'A')
+    assert "'A'" in str(exc_info.value)
+    assert "'B'" in str(exc_info.value)
+
+
+def test_malformed_mixin_string_not_list():
+    mixins = {'A': {'mixin': 'B'}}
+    with pytest.raises(InvalidMixinError):
+        compute_application_order(mixins, 'A')
+
+
+def test_malformed_mixin_list_with_non_string():
+    mixins = {
+        'A': {'mixin': ['B', 1]},
+        'B': {},
+    }
+    with pytest.raises(InvalidMixinError):
+        compute_application_order(mixins, 'A')
+
+
+def test_requested_mixin_not_in_dict():
+    mixins = {'A': {}}
+    with pytest.raises(MissingMixinError):
+        compute_application_order(mixins, 'Z')
+
+
+def test_mixin_key_never_in_output():
+    mixins = {
+        'A': {'mixin': ['B', 'D']},
+        'B': {'mixin': ['C']},
+        'C': {'mixin': ['D']},
+        'D': {},
+    }
+    order = compute_application_order(mixins, 'A')
+    assert 'mixin' not in order
+    assert set(order) <= set(mixins.keys())


### PR DESCRIPTION
Lets a mixin reference other mixins through a reserved `mixin` key holding a list of mixin names, so a bigger mixin can be built out of smaller ones. Addresses #39.

About the diff: this branch sits on top of #59, which is approved but not merged yet, so the four commits from that PR show up here as well. The composition work is the last two commits. Happy to rebase once #59 goes in.

- The new module `colcon_mixin/mixin/order.py` works out the application order with a depth first post-order walk. A mixin reachable through more than one path is applied once per path so that last one wins still holds, cycle detection only looks at the active recursion path, and circular, unknown or malformed references each raise their own error.

- In `mixin_argument.py` the references are applied before the mixin itself, so a mixin can override what it inherits. The reserved `mixin` key is skipped during the overlay since it is metadata and not an argument. Mixins that don't use the key behave exactly as before.

- `test/test_order.py` covers the ordering algorithm and the error cases, `test/test_mixin_argument.py` covers nested references, scalar overrides and command line precedence.

Claude Opus (via Antigravity) was used for generating test cases and for architecture level testing. The design, implementation and final review are my own.
